### PR TITLE
disable auto-deploy and standardize on Python 3.13

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,20 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - 'production'
+          - 'staging'
+  # Disabled auto-deploy on main branch - manual deployment only
+  # push:
+  #   branches:
+  #     - main
 
 permissions:
   contents: read

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-# Testing framework (Python 3.13-3.12)
+# Testing framework (Python 3.13)
 pytest>=7.4.0
 pytest-cov>=4.1.0
 pytest-mock>=3.11.1

--- a/tests/README.md
+++ b/tests/README.md
@@ -147,7 +147,7 @@ Tests run automatically on:
 - When Python files or test configurations change
 
 GitHub Actions workflow features:
-- Multi-version Python testing (3.12, 3.13)
+- Python 3.13 testing
 - Code coverage reporting to Codecov
 - Coverage comments on PRs
 - Security scanning with Bandit


### PR DESCRIPTION
## Summary
- Disable auto-deploy on main branch push (manual deployment only)
- Convert GitHub Pages deployment to workflow_dispatch trigger
- Remove Python 3.12 references from test requirements
- Standardize on Python 3.13 for all workflows and testing

## Test plan
- [x] Verified workflows use Python 3.13 only
- [x] Verified auto-deploy disabled on main branch
- [x] Verified manual deployment trigger configured
- [x] No functional changes to test or validation logic

🤖 Generated with [Claude Code](https://claude.ai/code)